### PR TITLE
Changed scripts to work with rimraf to support cross-platform development

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,58 +1,59 @@
 {
-  "name": "helpful-decorators",
-  "version": "1.3.0",
-  "description": "Helpful decorators for typescript applications",
-  "main": "dist/index.js",
-  "typings": "./dist/index.d.ts",
-  "jest": {
-    "moduleFileExtensions": [
-      "ts",
-      "js"
-    ],
-    "transform": {
-      "\\.(ts)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+    "name": "helpful-decorators",
+    "version": "1.3.1",
+    "description": "Helpful decorators for typescript applications",
+    "main": "dist/index.js",
+    "typings": "./dist/index.d.ts",
+    "jest": {
+        "moduleFileExtensions": [
+            "ts",
+            "js"
+        ],
+        "transform": {
+            "\\.(ts)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+        },
+        "testRegex": "/__tests__/.*\\.(ts|js)$"
     },
-    "testRegex": "/__tests__/.*\\.(ts|js)$"
-  },
-  "scripts": {
-    "build": "rm -rf ./dist && tsc",
-    "test": "jest",
-    "commit": "git cz",
-    "prepublish": "npm run build",
-    "setup": "semantic-release-cli setup",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
-  },
-  "config": {
-    "commitizen": {
-      "path": "node_modules/cz-conventional-changelog"
+    "scripts": {
+        "build": "rimraf ./dist && tsc",
+        "test": "jest",
+        "commit": "git cz",
+        "prepublish": "npm run build",
+        "setup": "semantic-release-cli setup",
+        "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    },
+    "config": {
+        "commitizen": {
+            "path": "node_modules/cz-conventional-changelog"
+        }
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/NetanelBasal/helpful-decorators"
+    },
+    "license": "MIT",
+    "author": "Netanel Basal",
+    "keywords": [
+        "decorators",
+        "setTimeout decorator",
+        "debounce decorator",
+        "once decorator"
+    ],
+    "devDependencies": {
+        "@types/jest": "^20.0.8",
+        "commitizen": "^2.9.6",
+        "cz-conventional-changelog": "^2.0.0",
+        "jest": "^21.0.1",
+        "semantic-release": "^7.0.2",
+        "semantic-release-cli": "^3.0.3",
+        "ts-jest": "^21.0.0",
+        "typescript": "^2.5.2",
+        "rimraf": "^2.6.2"
+    },
+    "dependencies": {
+        "conventional-changelog-cli": "^1.3.3",
+        "lodash.debounce": "^4.0.8",
+        "lodash.once": "^4.1.1",
+        "lodash.throttle": "^4.1.1"
     }
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/NetanelBasal/helpful-decorators"
-  },
-  "license": "MIT",
-  "author": "Netanel Basal",
-  "keywords": [
-    "decorators",
-    "setTimeout decorator",
-    "debounce decorator",
-    "once decorator"
-  ],
-  "devDependencies": {
-    "@types/jest": "^20.0.8",
-    "commitizen": "^2.9.6",
-    "cz-conventional-changelog": "^2.0.0",
-    "jest": "^21.0.1",
-    "semantic-release": "^7.0.2",
-    "semantic-release-cli": "^3.0.3",
-    "ts-jest": "^21.0.0",
-    "typescript": "^2.5.2"
-  },
-  "dependencies": {
-    "conventional-changelog-cli": "^1.3.3",
-    "lodash.debounce": "^4.0.8",
-    "lodash.once": "^4.1.1",
-    "lodash.throttle": "^4.1.1"
-  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4249,7 +4249,7 @@ right-pad@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/right-pad/-/right-pad-1.0.1.tgz#8ca08c2cbb5b55e74dafa96bf7fd1a27d568c8d0"
 
-rimraf@2, rimraf@^2.5.1, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@~2.6.2:
+rimraf@2, rimraf@^2.5.1, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:


### PR DESCRIPTION
Using `rimraf` instead of `rm -f`.