### PR TITLE
Added any as return type for decorators.

### DIFF
--- a/src/bind.ts
+++ b/src/bind.ts
@@ -6,7 +6,7 @@
  * and memoize the result against a symbol on the instance
  */
 
-export function bind(target, key, descriptor) {
+export function bind(target, key, descriptor): any {
   let fn = descriptor.value;
 
   if (typeof fn !== 'function') {

--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -1,6 +1,6 @@
 const debounceFn = require('lodash.debounce');
 
-export function debounce(milliseconds: number = 0, options = {}) {
+export function debounce(milliseconds: number = 0, options = {}): any {
   return function(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
     const map = new WeakMap();
     const originalMethod = descriptor.value;

--- a/src/delay.ts
+++ b/src/delay.ts
@@ -1,4 +1,4 @@
-export function delay(milliseconds: number = 0) {
+export function delay(milliseconds: number = 0): any {
   return function(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
     const originalMethod = descriptor.value;
 

--- a/src/measure.ts
+++ b/src/measure.ts
@@ -1,4 +1,4 @@
-export function measure(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+export function measure(target: any, propertyKey: string, descriptor: PropertyDescriptor): any {
   const originalMethod = descriptor.value;
 
   descriptor.value = function(...args) {

--- a/src/memoize.ts
+++ b/src/memoize.ts
@@ -1,6 +1,6 @@
 const memoizeFn = require('lodash.memoize');
 
-export function memo(resolver?) {
+export function memo(resolver?): any {
   return function(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
     descriptor.value = memoizeFn(descriptor.value, resolver);
     return descriptor;

--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -1,4 +1,4 @@
-export function Mixin(baseCtors: Function[]) {
+export function Mixin(baseCtors: Function[]): any {
   return function(derivedCtor: Function) {
     baseCtors.forEach(baseCtor => {
       Object.getOwnPropertyNames(baseCtor.prototype).forEach(name => {

--- a/src/once.ts
+++ b/src/once.ts
@@ -1,6 +1,6 @@
 const onceFn = require('lodash.once');
 
-export function once(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+export function once(target: any, propertyKey: string, descriptor: PropertyDescriptor): any {
   const originalMethod = descriptor.value;
   descriptor.value = onceFn(originalMethod);
   return descriptor;

--- a/src/throttle.ts
+++ b/src/throttle.ts
@@ -1,6 +1,6 @@
 const throttleFn = require('lodash.throttle');
 
-export function throttle(milliseconds: number = 0, options = {}) {
+export function throttle(milliseconds: number = 0, options = {}): any {
   return function(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
     const originalMethod = descriptor.value;
     descriptor.value = throttleFn(originalMethod, milliseconds, options);


### PR DESCRIPTION
A TypeScript compiler fix for TS1240/TS1241, referenced [here](https://stackoverflow.com/questions/37694322/typescript-ts1241-unable-to-resolve-signature-of-method-decorator-when-called-a).

All of the decorator function return types were made to be `any` to resolve this compiler error.